### PR TITLE
Modernize Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 julia:
-  - 0.3
   - 0.4
   - 0.5
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+julia:
+  - 0.3
+  - 0.4
+  - 0.5
+  - nightly
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Shannon")'
+#script: # use the default script setting which is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Shannon")'
 after_success:
   - julia -e 'cd(Pkg.dir("Shannon")); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
`language: julia` allows testing against more versions of Julia (and optionally osx)
and is more up to date than the PPA.

Since REQUIRE still lists Julia 0.3 as the minimum version, that should be tested.
If 0.3 is no longer supported, then REQUIRE should be changed.
